### PR TITLE
feat: trim clipboard text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,7 @@ function App() {
             })
             return;
         }
-        const settingsTextList = settingsText.split("\n");
+        const settingsTextList = settingsText.trim().split("\n");
         let loadedEntriesNum = 0;
         let erroredLinesNum = 0;
         settingsTextList.forEach((line) => {


### PR DESCRIPTION
Users sometimes copy INI content with extra newline characters.