### PR TITLE
feat: add RandomizerType and RandomizerSeed

### DIFF
--- a/src/assets/i18n/de-DE.json
+++ b/src/assets/i18n/de-DE.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "Schwierigkeit",
+        "RandomizerType": "Zufallstyp",
+        "RandomizerSeed": "Zufallskeim",
         "DayTimeSpeedRate": "Zeit Geschwindigkeit am Tag",
         "NightTimeSpeedRate": "Zeit Geschwindigkeit bei Nacht",
         "ExpRate": "Exp Rate",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "Textformat zum Protokollieren verwenden",
           "Json": "Json-Format zum Protokollieren verwenden"
+        },
+        "RandomizerType": {
+          "None": "Kein Zufallstyp festgelegt",
+          "Region": "Auf Zufallsregion eingestellt",
+          "All": "Auf vollständige Zufälligkeit eingestellt"
         }
       }
     }

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "Difficulty",
+        "RandomizerType": "Randomizer Type",
+        "RandomizerSeed": "Randomizer Seed",
         "DayTimeSpeedRate": "Day Time Speed Rate",
         "NightTimeSpeedRate": "Night Time Speed Rate",
         "ExpRate": "Exp Rate",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "Use Text format to log",
           "Json": "Use Json format to log"
+        },
+        "RandomizerType": {
+          "None": "No randomizer set",
+          "Region": "Set to randomize region",
+          "All": "Set to randomize all"
         }
       }
     }

--- a/src/assets/i18n/es-ES.json
+++ b/src/assets/i18n/es-ES.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "Dificultad",
+        "RandomizerType": "Tipo de Aleatorizador",
+        "RandomizerSeed": "Semilla del Aleatorizador",
         "DayTimeSpeedRate": "Ratio de Velocidad del Tiempo de Día",
         "NightTimeSpeedRate": "Ratio de Velocidad del Tiempo de Noche",
         "ExpRate": "Ratio de Experiencia",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "Usar formato de texto para registrar",
           "Json": "Usar formato Json para registrar"
+        },
+        "RandomizerType": {
+          "None": "Ningún aleatorizador establecido",
+          "Region": "Establecido para aleatorizar la región",
+          "All": "Establecido para aleatorizar todo"
         }
       }
     }

--- a/src/assets/i18n/ja-JP.json
+++ b/src/assets/i18n/ja-JP.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "難易度",
+        "RandomizerType": "ランダマイザータイプ",
+        "RandomizerSeed": "ランダマイザーシード",
         "DayTimeSpeedRate": "昼の経過速度",
         "NightTimeSpeedRate": "夜の経過速度",
         "ExpRate": "経験値の入手倍率",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "テキスト形式を使用してログを記録",
           "Json": "Json形式を使用してログを記録"
+        },
+        "RandomizerType": {
+          "None": "ランダマイザーが設定されていません",
+          "Region": "地域をランダムに設定",
+          "All": "すべてをランダムに設定"
         }
       }
     }

--- a/src/assets/i18n/ko-KR.json
+++ b/src/assets/i18n/ko-KR.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "난이도",
+        "RandomizerType": "랜덤화 유형",
+        "RandomizerSeed": "랜덤화 시드",
         "DayTimeSpeedRate": "낮 시간 속도 배율",
         "NightTimeSpeedRate": "밤 시간 속도 배율",
         "ExpRate": "경험치 배율",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "텍스트 형식을 사용하여 로그 기록",
           "Json": "Json 형식을 사용하여 로그 기록"
+        },
+        "RandomizerType": {
+          "None": "랜덤화 설정 없음",
+          "Region": "지역 랜덤화 설정",
+          "All": "전체 랜덤화 설정"
         }
       }
     }

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "Ajusta a dificuldade geral do jogo.",
+        "RandomizerType": "Tipo de Aleatorizador",
+        "RandomizerSeed": "Semente do Aleatorizador",
         "DayTimeSpeedRate": "Modifica a velocidade do tempo de jogo durante o dia.",
         "NightTimeSpeedRate": "Modifica a velocidade do tempo de jogo durante a noite.",
         "ExpRate": "Altera a taxa de ganho de experiência para jogadores e criaturas.",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "Usar formato de texto para log",
           "Json": "Usar formato Json para log"
+        },
+        "RandomizerType": {
+          "None": "Nenhum aleatorizador definido",
+          "Region": "Configurado para aleatorizar região",
+          "All": "Configurado para aleatorizar tudo"
         }
       }
     }

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "难度",
+        "RandomizerType": "随机器类型",
+        "RandomizerSeed": "随机种子",
         "DayTimeSpeedRate": "白天流逝速度",
         "NightTimeSpeedRate": "夜间流逝速度",
         "ExpRate": "经验值倍率",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "使用文本格式记录日志",
           "Json": "使用 JSON 格式记录日志"
+        },
+        "RandomizerType": {
+          "None": "未设置随机器",
+          "Region": "设置为随机地区",
+          "All": "设置为完全随机"
         }
       }
     }

--- a/src/assets/i18n/zh-TW.json
+++ b/src/assets/i18n/zh-TW.json
@@ -47,6 +47,8 @@
     "entry": {
       "name": {
         "Difficulty": "遊戲難度",
+        "RandomizerType": "隨機器類型",
+        "RandomizerSeed": "隨機種子",
         "DayTimeSpeedRate": "白天流逝速度",
         "NightTimeSpeedRate": "夜晚流逝速度",
         "ExpRate": "經驗值倍率",
@@ -142,6 +144,11 @@
         "LogFormatType": {
           "Text": "使用文本格式記錄日誌",
           "Json": "使用Json格式記錄日誌"
+        },
+        "RandomizerType": {
+          "None": "未設定隨機器",
+          "Region": "設定為隨機地區",
+          "All": "設定為全面隨機"
         }
       }
     }

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { useTranslation, Trans } from 'react-i18next';
 import { ChevronDown } from "lucide-react"
 
-import { DeathPenaltyLabels, AllowConnectPlatformLabels, LogFormatTypeLabels } from "@/consts/dropdownLabels"
+import { DeathPenaltyLabels, AllowConnectPlatformLabels, LogFormatTypeLabels, RandomizerTypeLabels } from "@/consts/dropdownLabels"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import {
@@ -26,9 +26,9 @@ import {
 } from "@/components/ui/tooltip"
 import { I18nStr } from "@/i18n";
 
-type Labels = typeof DeathPenaltyLabels | typeof AllowConnectPlatformLabels | typeof LogFormatTypeLabels;
+type Labels = typeof DeathPenaltyLabels | typeof AllowConnectPlatformLabels | typeof LogFormatTypeLabels | typeof RandomizerTypeLabels;
 export type LabelValue = Labels[number]['name'];
-type Key =  'DeathPenalty' | 'AllowConnectPlatform' | 'LogFormatType';
+type Key =  'DeathPenalty' | 'AllowConnectPlatform' | 'LogFormatType' | 'RandomizerType';
 
 function get<T>(dict: Record<string, T>, key: string, defaultValue: T): T {
     return Object.prototype.hasOwnProperty.call(dict, key) ? dict[key] : defaultValue;
@@ -43,7 +43,8 @@ export function DropDown(props: {
     const labels = {
       DeathPenalty: DeathPenaltyLabels,
       AllowConnectPlatform: AllowConnectPlatformLabels,
-      LogFormatType: LogFormatTypeLabels
+      LogFormatType: LogFormatTypeLabels,
+      RandomizerType: RandomizerTypeLabels
     }[dKey] as Labels;
     const { t } = useTranslation();
     const [open, setOpen] = useState(false);

--- a/src/consts/dropdownLabels.tsx
+++ b/src/consts/dropdownLabels.tsx
@@ -38,3 +38,18 @@ export const LogFormatTypeLabels = [
         desc: "Use Json format to log",
     },
 ] as const;
+
+export const RandomizerTypeLabels = [
+    {
+        name: "None",
+        desc: "No randomizer set"
+    },
+    {
+        name: "Region",
+        desc: "Set to randomize region"
+    },
+    {
+        name: "All",
+        desc: "Set to randomize all"
+    }
+] as const;

--- a/src/consts/entries.tsx
+++ b/src/consts/entries.tsx
@@ -86,6 +86,21 @@ export const ENTRIES: Record<string, Entry> = {
     type: "select",
     options: ["None"],
   },
+  RandomizerType: {
+    name: "Randomizer Type",
+    id: "RandomizerType",
+    defaultValue: "None",
+    type: "select",
+    options: ["None", "Region", "All"],
+    desc: "Randomizer type",
+  },
+  RandomizerSeed: {
+    name: "Randomizer Seed",
+    id: "RandomizerSeed",
+    defaultValue: "",
+    type: "string",
+    desc: "Randomizer seed",
+  },
   DayTimeSpeedRate: {
     name: "Day Time Speed Rate",
     id: "DayTimeSpeedRate",

--- a/src/consts/settings.tsx
+++ b/src/consts/settings.tsx
@@ -9,7 +9,9 @@ export const ServerSettings = [
   "bIsUseBackupSaveData",
   "AutoSaveSpan",
   "AllowConnectPlatform",
-  "LogFormatType"
+  "LogFormatType",
+  "RandomizerType",
+  "RandomizerSeed",
 ];
 
 export const InGameSettings = [

--- a/src/consts/worldoption.tsx
+++ b/src/consts/worldoption.tsx
@@ -324,6 +324,17 @@ export const DEFAULT_WORLDOPTION = {
                             enum_type: "EPalOptionWorldDifficulty",
                           },
                         },
+                        RandomizerType: {
+                          Enum: {
+                            value: "EPalRandomizerType::None",
+                            enum_type: "EPalRandomizerType",
+                          },
+                        },
+                        RandomizerSeed: {
+                          Str: {
+                            value: "",
+                          },
+                        },
                         DayTimeSpeedRate: {
                           Float: {
                             value: 4.590592,


### PR DESCRIPTION
Adding support for `RandomizerType` and `RandomizerSeed`

Had to go through the game files to find the Enum for the RandomizerType. Have it set to `EPalRandomizerType` for the world options. 