### PR TITLE
feat: add bIsRandomizerPalLevelRandom, bAllowGlobalPalboxExport, and …

### DIFF
--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -49,6 +49,7 @@
         "Difficulty": "Difficulty",
         "RandomizerType": "Randomizer Type",
         "RandomizerSeed": "Randomizer Seed",
+        "bIsRandomizerPalLevelRandom": "Is Randomizer Pal Level Random",
         "DayTimeSpeedRate": "Day Time Speed Rate",
         "NightTimeSpeedRate": "Night Time Speed Rate",
         "ExpRate": "Exp Rate",
@@ -128,7 +129,9 @@
         "bUseAuth": "Use Auth",
         "BanListURL": "Ban List URL",
         "SupplyDropSpan":"Interval for supply drop or meteorite (minutes)",
-        "ChatPostLimitPerMinute":"Chat Post Limit Per Minute"
+        "ChatPostLimitPerMinute":"Chat Post Limit Per Minute",
+        "bAllowGlobalPalboxExport":"Allow Global Palbox Export",
+        "bAllowGlobalPalboxImport":"Allow Global Palbox Import"
       },
       "description": {
         "DeathPenalty": {

--- a/src/consts/entries.tsx
+++ b/src/consts/entries.tsx
@@ -101,6 +101,13 @@ export const ENTRIES: Record<string, Entry> = {
     type: "string",
     desc: "Randomizer seed",
   },
+  bIsRandomizerPalLevelRandom: {
+    name: "Randomizer Pal Level Random",
+    id: "bIsRandomizerPalLevelRandom",
+    defaultValue: "False",
+    type: "boolean",
+    desc: "Randomizer pal level random",
+  },
   DayTimeSpeedRate: {
     name: "Day Time Speed Rate",
     id: "DayTimeSpeedRate",
@@ -704,5 +711,19 @@ export const ENTRIES: Record<string, Entry> = {
     type: "float",
     range: [5000, 15000],
     desc: "Pal sync distance from player",
+  },
+  bAllowGlobalPalboxExport:{
+    name: "Allow Global Palbox Export",
+    id: "bAllowGlobalPalboxExport",
+    defaultValue: "True",
+    type: "boolean",
+    desc: "Allow global palbox export",
+  },
+  bAllowGlobalPalboxImport:{
+    name: "Allow Global Palbox Import",
+    id: "bAllowGlobalPalboxImport",
+    defaultValue: "False",
+    type: "boolean",
+    desc: "Allow global palbox import",
   },
 };

--- a/src/consts/settings.tsx
+++ b/src/consts/settings.tsx
@@ -12,6 +12,9 @@ export const ServerSettings = [
   "LogFormatType",
   "RandomizerType",
   "RandomizerSeed",
+  "bIsRandomizerPalLevelRandom",
+  "bAllowGlobalPalboxExport",
+  "bAllowGlobalPalboxImport"
 ];
 
 export const InGameSettings = [

--- a/src/consts/worldoption.tsx
+++ b/src/consts/worldoption.tsx
@@ -335,6 +335,21 @@ export const DEFAULT_WORLDOPTION = {
                             value: "",
                           },
                         },
+                        bIsRandomizerPalLevelRandom: {
+                          Bool: {
+                            value: true,
+                          },
+                        },
+                        bAllowGlobalPalboxExport: {
+                          Bool: {
+                            value: false,
+                          },
+                        },
+                        bAllowGlobalPalboxImport: {
+                          Bool: {
+                            value: true,
+                          },
+                        },
                         DayTimeSpeedRate: {
                           Float: {
                             value: 4.590592,


### PR DESCRIPTION
**Three new settings added:**
- bIsRandomizerPalLevelRandom
- bAllowGlobalPalboxExport
- bAllowGlobalPalboxImport

With the recent updated they added another setting for crossplay provided below;
```
CrossplayPlatforms=(Steam,Xbox,PS5,Mac)
```

I am not 100% sure how this would be implemented with the `WorldOptions.sav` I provided what I found in the files below. Not sure how it's done from a server side perspective, this was grabbed from the PAK files. Not sure if you could do a proper implementation for this @Bluefissure eeeeeeeeee.
```
        "CrossplayPlatforms": [
          "EPalAllowConnectPlatform::Steam",
          "EPalAllowConnectPlatform::Xbox",
          "EPalAllowConnectPlatform::PS5",
          "EPalAllowConnectPlatform::Mac"
        ],
```