### PR TITLE
bAllowGlobalPalboxImport default value to False

### DIFF
--- a/src/consts/entries.tsx
+++ b/src/consts/entries.tsx
@@ -721,7 +721,7 @@ export const ENTRIES: Record<string, Entry> = {
   bAllowGlobalPalboxImport:{
     name: "Allow Global Palbox Import",
     id: "bAllowGlobalPalboxImport",
-    defaultValue: "True",
+    defaultValue: "False",
     type: "boolean",
     desc: "Allow global palbox import",
   },

--- a/src/consts/worldoption.tsx
+++ b/src/consts/worldoption.tsx
@@ -347,7 +347,7 @@ export const DEFAULT_WORLDOPTION_SAV = {
                         },
                         bAllowGlobalPalboxImport: {
                           Bool: {
-                            value: true,
+                            value: false,
                           },
                         },
                         DayTimeSpeedRate: {


### PR DESCRIPTION
Following Pull request #66  
**bAllowGlobalPalworldImport** was set to Default = **True** while it seems that it's Default to **False**
**bAllowGlobalPalboxExport** has default value to **True**, this one is OK

So when I load my WorldOption.sav it does not allow to set it to True
